### PR TITLE
Use static_pointer_cast for converting CallbackInfoBase to CallbackInfo<...> subclass, add arguments type information check in CallbacksInvoker::emit.

### DIFF
--- a/cocos/core/event/CallbacksInvoker.cpp
+++ b/cocos/core/event/CallbacksInvoker.cpp
@@ -213,22 +213,6 @@ void CallbacksInvoker::offAll() {
     }
 }
 
-void CallbacksInvoker::off(const std::string &key, CallbackInfoBase::ID cbID, void *target) {
-    auto iter = _callbackTable.find(key);
-    if (iter != _callbackTable.end()) {
-        auto &      list  = iter->second;
-        const auto &infos = list._callbackInfos;
-        size_t      i     = 0;
-        for (const auto &info : infos) {
-            if (info != nullptr && info->_id == cbID && info->_target == target) {
-                list.cancel(i);
-                break;
-            }
-            ++i;
-        }
-    }
-}
-
 void CallbacksInvoker::off(const std::string &key, CallbackInfoBase::ID cbID) {
     auto iter = _callbackTable.find(key);
     if (iter != _callbackTable.end()) {

--- a/cocos/core/platform/event-manager/EventCustom.cpp
+++ b/cocos/core/platform/event-manager/EventCustom.cpp
@@ -29,7 +29,8 @@
 NS_CC_EVENT_BEGIN
 
 EventCustom::EventCustom(const std::string &eventName)
-: Event(Type::CUSTOM), _userData(nullptr), _eventName(eventName) {
+: Event(Type::CUSTOM), _userData(nullptr) {
+    _eventName = eventName;
 }
 
 NS_CC_EVENT_END

--- a/cocos/core/platform/event-manager/EventCustom.h
+++ b/cocos/core/platform/event-manager/EventCustom.h
@@ -60,15 +60,8 @@ public:
      */
     void *getUserData() const { return _userData; }
 
-    /** Gets event name.
-     *
-     * @return The name of the event.
-     */
-    const std::string &getEventName() const { return _eventName; }
-
 protected:
-    void *      _userData; ///< User data
-    std::string _eventName;
+    void *_userData; ///< User data
 };
 
 NS_CC_EVENT_END

--- a/cocos/core/scene-graph/Node.cpp
+++ b/cocos/core/scene-graph/Node.cpp
@@ -150,6 +150,16 @@ void Node::off(const std::string &type, bool useCapture) {
     }
 }
 
+void Node::off(const std::string &type, CallbackInfoBase::ID cbID, bool useCapture /* = false*/) {
+    _eventProcessor->off(type, cbID, useCapture);
+    bool hasListeners = _eventProcessor->hasEventListener(type);
+    if (!hasListeners) {
+        if (type == NodeEventType::TRANSFORM_CHANGED) {
+            _eventMask &= ~TRANSFORM_ON;
+        }
+    }
+}
+
 void Node::off(const std::string &type, void *target, bool useCapture) {
     _eventProcessor->off(type, target, useCapture);
     bool hasListeners = _eventProcessor->hasEventListener(type);

--- a/cocos/core/scene-graph/Node.h
+++ b/cocos/core/scene-graph/Node.h
@@ -149,6 +149,8 @@ public:
 
     void off(const std::string &type, bool useCapture = false);
 
+    void off(const std::string &type, CallbackInfoBase::ID cbID, bool useCapture = false);
+
     void off(const std::string &type, void *target, bool useCapture = false);
 
     template <typename Target, typename... Args>

--- a/cocos/core/scene-graph/NodeEventProcessor.h
+++ b/cocos/core/scene-graph/NodeEventProcessor.h
@@ -107,7 +107,7 @@ public:
 
     void off(const std::string &type, CallbackInfoBase::ID cbID, bool useCapture = false);
 
-    void off(const std::string &type, void *target, CallbackInfoBase::ID cbID, bool useCapture = false);
+    void off(const std::string &type, void *target, bool useCapture = false);
 
     template <typename Target, typename... Args>
     void off(const std::string &type, void (Target::*memberFn)(Args...), Target *target, bool useCapture = false);
@@ -171,7 +171,7 @@ private:
     void onDispatch(const std::string &type, std::function<void(Args...)> &&callback, Target *target, CallbackInfoBase::ID &cbID, bool useCapture = false);
 
     void offDispatch(const std::string &type, CallbackInfoBase::ID cbID, bool useCapture = false);
-    void offDispatch(const std::string &type, CallbackInfoBase::ID cbID, void *target, bool useCapture = false);
+    void offDispatch(const std::string &type, void *target, bool useCapture = false);
 
     template <typename Target, typename... Args>
     void offDispatch(const std::string &type, void (Target::*memberFn)(Args...), Target *target, bool useCapture = false);

--- a/tests/unit-test/src/core_event_callbacksinvoker.cpp
+++ b/tests/unit-test/src/core_event_callbacksinvoker.cpp
@@ -214,7 +214,7 @@ TEST(CoreEventCallbacksInvoker, output_log) {
 TEST(CoreEventCallbacksInvoker, member_function_target) {
     CallbacksInvoker ci;
 
-    static int ccc;
+    static int ccc = 123344;
     class MyFoo : public CCObject {
     public:
         void foo(int a, float b, int *c) {
@@ -362,7 +362,7 @@ TEST(CoreEventCallbacksInvoker, remove_self_with_target_during_invoking) {
     CallbackInfoBase::ID id1{0};
 
     TestFunctor<> cb1{[&]() {
-        ci.off("eve", id1, &target);
+        ci.off("eve", id1);
     }};
 
     TestFunctor<> cb2{[]() {}};
@@ -402,7 +402,7 @@ TEST(CoreEventCallbacksInvoker, remove_previous_with_target_during_invoking) {
 
     TestFunctor<> cb1{[]() {}};
     TestFunctor<> cb2{[&]() {
-        ci.off("eve", id1, &target);
+        ci.off("eve", id1);
     }};
 
     ci.on("eve", cb1, &target, id1);
@@ -437,7 +437,7 @@ TEST(CoreEventCallbacksInvoker, remove_last_with_target_during_invoking) {
 
     TestFunctor<> cb1{[]() {}};
     TestFunctor<> cb2{[&]() {
-        ci.off("eve", id2, &target);
+        ci.off("eve", id2);
     }};
 
     ci.on("eve", cb1, &target, id1);
@@ -456,10 +456,10 @@ TEST(CoreEventCallbacksInvoker, remove_multiple_callbacks_during_invoking) {
     TestFunctor<> cb1{[]() {}};
     TestFunctor<> cb2{[&]() {
         ci.off("eve", id1);
-        ci.off("eve", id31, &target);
+        ci.off("eve", id31);
     }};
     TestFunctor<> cb3{[&]() {
-        ci.off("eve", id2, &target);
+        ci.off("eve", id2);
     }};
 
     ci.on("eve", cb1, id1);
@@ -490,7 +490,7 @@ TEST(CoreEventCallbacksInvoker, remove_all_callbacks_during_invoking) {
         ci.offAll("eve");
     }};
     TestFunctor<> cb3{[&]() {
-        ci.off("eve", id2, &target);
+        ci.off("eve", id2);
     }};
 
     ci.on("eve", cb1, id1);
@@ -570,9 +570,9 @@ TEST(CoreEventCallbacksInvoker, CallbacksInvoker_support_target) {
     EXPECT_EQ(cb3.getCalledCount(), 2);
 
     ci.off("b", id1_not_target1);
-    ci.off("b", id1_target22, &target22);
+    ci.off("b", id1_target22);
     EXPECT_TRUE(ci.hasEventListener("b", &target11, id1_b1));
-    ci.off("b", id1_b1, &target11);
+    ci.off("b", id1_b1);
     EXPECT_FALSE(ci.hasEventListener("b", &target11, id1_b1));
 
     target11.count         = 0;
@@ -581,9 +581,9 @@ TEST(CoreEventCallbacksInvoker, CallbacksInvoker_support_target) {
     cb2.clear();
     cb3.clear();
 
-    ci.off("a", id1_target22, &target22);
-    ci.off("a", id1_target11, &target11);
-    ci.off("a", id21, &target22);
+    ci.off("a", id1_target22);
+    ci.off("a", id1_target11);
+    ci.off("a", id21);
     ci.emit("a");
 
     EXPECT_EQ(myTargetFooCalledCount, 2);


### PR DESCRIPTION
Also

- Remove some unused off methods, off doesn't need both cbID & target
- Update unittest & EventCustom.