### PR TITLE
support static fields

### DIFF
--- a/tools/bindings-generator/generator.py
+++ b/tools/bindings-generator/generator.py
@@ -777,7 +777,7 @@ class NativeField(object):
         cursor = cursor.canonical
         self.cursor = cursor
         self.name = cursor.displayname
-        new_name = generator.should_rename_function(native_class, self.name) 
+        new_name = generator.should_rename_function(native_class.class_name, self.name)
         self.export_name = new_name if new_name is not None else self.name
         self.kind = cursor.type.kind
         self.is_static = cursor.storage_class.value == 3 and cursor.kind == cindex.CursorKind.VAR_DECL
@@ -795,7 +795,7 @@ class NativeField(object):
 
     def toJSON(self):
         return {
-            "name": self.name,
+            "name": self.export_name,
             "pretty_name": self.pretty_name,
             "signature_name" : self.signature_name,
             "type": self.ntype.toJSON(),
@@ -1279,7 +1279,7 @@ class NativeClass(object):
                         "names": x["names"],
                         "type": x["getter"].ret_type.toJSON() if x["getter"] is not None else (x["setter"].arguments[0].toJSON() if x["setter"] is not None else None)
                     }, self.getter_setter)),
-            "methods": dict(map(lambda kv: (kv[0], kv[1].toJSON()), filter(lambda f: not self.generator.should_skip(self.class_name,f[0]), self.methods.items()))),
+            "methods": dict(map(lambda kv: (kv[0], kv[1].toJSON()), filter(lambda f: not self.skip_bind_function({"name":f[0]}), self.methods.items()))),
             "static_methods": dict(map(lambda kv: (kv[0], kv[1].toJSON()), filter(lambda x: not self.generator.should_skip(self.class_name, x[0]), self.static_methods.items()))),
             "dict_of_override_method_should_be_bound": dict(map(lambda kv: (kv[0], list(map(lambda x: x.toJSON(), kv[1]))), self.dict_of_override_method_should_be_bound.items())),
         }

--- a/tools/bindings-generator/generator.py
+++ b/tools/bindings-generator/generator.py
@@ -1187,12 +1187,12 @@ class NativeClass(object):
         return self.namespaced_class_name.replace("::", "_")
 
     def skip_bind_function(self, method_name):
-        if self.generator.is_reserved_function(self.class_name, method_name["name"]):
-            return False
         if self.class_name in self.generator.shadowed_methods_by_getter_setter:
             ret = method_name["name"] in self.generator.shadowed_methods_by_getter_setter[self.class_name]
             # logger.info("??? skip %s contains %s , %s" %(self.generator.shadowed_methods_by_getter_setter[self.class_name], method_name, ret))
             return ret
+        if self.generator.is_reserved_function(self.class_name, method_name["name"]):
+            return False
         return False
 
     def find_method(self, method_name):
@@ -1241,7 +1241,8 @@ class NativeClass(object):
         for name, impl in iter(self.static_methods.items()):
             should_skip = self.generator.should_skip(self.class_name, name)
             if not should_skip:
-                ret.append({"name": name, "impl": impl})
+                ret.append({"name":  self.generator.should_rename_function(
+                    self.class_name, name) or name, "impl": impl})
         return sorted(ret, key=lambda fn: fn["name"])
 
     def override_methods_clean(self):

--- a/tools/bindings-generator/generator.py
+++ b/tools/bindings-generator/generator.py
@@ -799,7 +799,8 @@ class NativeField(object):
             "pretty_name": self.pretty_name,
             "signature_name" : self.signature_name,
             "type": self.ntype.toJSON(),
-            "static": self.is_static,
+            "is_static": self.is_static,
+            "is_static_const": self.is_static_const,
         }
 
     @staticmethod

--- a/tools/bindings-generator/targets/spidermonkey/templates/layout_foot.c
+++ b/tools/bindings-generator/targets/spidermonkey/templates/layout_foot.c
@@ -26,3 +26,4 @@ bool register_all_${prefix}(se::Object* obj)    // NOLINT
 #if $macro_judgement
 \#endif //$macro_judgement
 #end if
+// clang-format on

--- a/tools/bindings-generator/targets/spidermonkey/templates/layout_foot.h
+++ b/tools/bindings-generator/targets/spidermonkey/templates/layout_foot.h
@@ -2,3 +2,5 @@
 #if $macro_judgement
 \#endif //$macro_judgement
 #end if
+
+// clang-format on

--- a/tools/bindings-generator/targets/spidermonkey/templates/layout_head.c
+++ b/tools/bindings-generator/targets/spidermonkey/templates/layout_head.c
@@ -1,3 +1,5 @@
+
+// clang-format off
 \#include "${os.path.relpath(os.path.join($outdir, $out_file + '.h'), $search_path+'/..').replace(os.path.sep, '/')}"
 #if $macro_judgement
 $macro_judgement

--- a/tools/bindings-generator/targets/spidermonkey/templates/layout_head.h
+++ b/tools/bindings-generator/targets/spidermonkey/templates/layout_head.h
@@ -1,3 +1,4 @@
+// clang-format off
 #pragma once
 \#include "base/Config.h"
 #if $macro_judgement

--- a/tools/bindings-generator/targets/spidermonkey/templates/public_static_field.c
+++ b/tools/bindings-generator/targets/spidermonkey/templates/public_static_field.c
@@ -1,0 +1,71 @@
+## ===== member implementation template
+
+static bool ${signature_name}_get_${name}(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    CC_UNUSED bool ok = true;
+    se::Value jsret;
+    #if $ntype.is_object and not $ntype.object_can_convert($generator, False)
+    ${ntype.from_native({"generator": $generator,
+                         "type_name": $ntype.namespaced_class_name.replace("*", ""),
+                         "ntype": $ntype.get_whole_name($generator),
+                         "level": 2,
+                         "in_value": $namespaced_class_name + "::" + $pretty_name,
+                         "out_value": "jsret",
+                         "context" :  "s.thisObject()"
+                        })};
+    #else
+    ${ntype.from_native({"generator": $generator,
+                         "type_name": $ntype.namespaced_class_name.replace("*", ""),
+                         "ntype": $ntype.get_whole_name($generator),
+                         "level": 2,
+                         "scriptname": $generator.scriptname_from_native($ntype.namespaced_class_name, $ntype.namespace_name),
+                         "in_value": $namespaced_class_name + "::" + $pretty_name,
+                         "out_value": "jsret",
+                         "context" :  "s.thisObject()"
+                         })};
+    #end if
+    s.rval() = jsret;
+    // SE_HOLD_RETURN_VALUE(cobj->${pretty_name}, s.thisObject(), s.rval());
+    return true;
+}
+SE_BIND_PROP_GET(${signature_name}_get_${name})
+
+#if not $is_static_const
+static bool ${signature_name}_set_${name}(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    const auto& args = s.args();
+    SE_PRECONDITION2(args.size() == 1, false, "${signature_name}_set_${name} : arguments count incorrect");
+
+    CC_UNUSED bool ok = true;
+    #set $arg_type = $ntype.to_string($generator)
+#if $ntype.is_object and not $ntype.object_can_convert($generator)
+    #set conv_text = $ntype.to_native({"generator": $generator, \
+                        "arg_idx": 2, \
+                        "arg_type": $arg_type, \
+                        "ntype": $ntype.get_whole_name($generator), \
+                        "in_value": "args[0]", \
+                        "out_value": $namespaced_class_name + "::" + $pretty_name, \
+                        "func_name": $name, \
+                        "level": 2, \
+                        "arg":$ntype, \
+                        "context" :  "s.thisObject()" \
+                    })
+#else
+    #set conv_text = $ntype.to_native({"generator": $generator, \
+                        "arg_idx": 2, \
+                        "arg_type": $arg_type, \
+                        "in_value": "args[0]", \
+                        "out_value": $namespaced_class_name + "::" + $pretty_name, \
+                        "func_name": $name, \
+                        "scriptname": $generator.scriptname_from_native($ntype.namespaced_class_name, $ntype.namespace_name), \
+                        "level": 2, \
+                        "arg":$ntype, \
+                        "context" :  "s.thisObject()" \
+                    })
+#end if
+    $conv_text;
+    SE_PRECONDITION2(ok, false, "${signature_name}_set_${name} : Error processing new value");
+    return true;
+}
+SE_BIND_PROP_SET(${signature_name}_set_${name})
+#end if

--- a/tools/bindings-generator/targets/spidermonkey/templates/register.c
+++ b/tools/bindings-generator/targets/spidermonkey/templates/register.c
@@ -11,7 +11,6 @@ ${current_class.generate_struct_constructor()}
 #set constructor = $current_class.methods.constructor
 ${current_class.methods.constructor.generate_code($current_class)}
 #end if
-
 #if $generator.in_listed_extend_classed($current_class.class_name) and $has_constructor
 #if not $constructor.is_overloaded
     ${constructor.generate_code($current_class, None, False, True)}
@@ -19,7 +18,6 @@ ${current_class.methods.constructor.generate_code($current_class)}
     ${constructor.generate_code($current_class, False, True)}
 #end if
 #end if
-
 #if not $current_class.is_abstract
 static bool js_${current_class.underlined_class_name}_finalize(se::State& s) // NOLINT(readability-identifier-naming)
 {
@@ -90,8 +88,8 @@ bool js_register_${generator.prefix}_${current_class.nested_class_name}(se::Obje
 #end if
 
 #for m in public_fields
-    #if  $current_class.should_export_field(m.name)
-    cls->defineProperty("${m.name}", _SE(${m.signature_name}_get_${m.name}), _SE(${m.signature_name}_set_${m.name}));
+    #if  $current_class.should_export_field(m.name) and not m.is_static
+    cls->defineProperty("${m.export_name}", _SE(${m.signature_name}_get_${m.name}), _SE(${m.signature_name}_set_${m.name}));
     #end if
 #end for
 #for m in $current_class.getter_setter
@@ -126,9 +124,18 @@ bool js_register_${generator.prefix}_${current_class.nested_class_name}(se::Obje
     __jsb_${current_class.underlined_class_name}_proto = cls->getProto();
     __jsb_${current_class.underlined_class_name}_class = cls;
 
+    #set static_fields = list(filter(lambda m: $current_class.should_export_field(m.name) and m.is_static, public_fields))
+#if len(static_fields) > 0
+    // static fields
+#for m in static_fields
+    #set static_setter = "_SE("+m.signature_name+"_set_"+m.name+")" if not m.is_static_const else "nullptr"
+    __jsb_${current_class.underlined_class_name}_proto->defineProperty("${m.export_name}", _SE(${m.signature_name}_get_${m.name}), ${static_setter});
+#end for
+#end if
 #if $generator.in_listed_extend_classed($current_class.class_name) and not $current_class.is_abstract
     jsb_set_extend_property("${generator.target_ns}", "${current_class.target_class_name}");
 #end if
+
     se::ScriptEngine::getInstance()->clearException();
     return true;
 }

--- a/tools/tojs/gen_d_ts/decl/typeinfo.d.ts
+++ b/tools/tojs/gen_d_ts/decl/typeinfo.d.ts
@@ -27,6 +27,8 @@ declare interface NativeField {
     pretty_name: string;
     signature_name: string;
     type: NativeType;
+    is_static: boolean;
+    is_static_const:boolean;
 }
 
 

--- a/tools/tojs/gen_d_ts/index.ts
+++ b/tools/tojs/gen_d_ts/index.ts
@@ -458,7 +458,7 @@ function processClass(klass: NativeClass): string {
             let maxMiddle = 0;
             let lines: [string, string, string][] = [];
             for (let attr of klass.public_fields) {
-                let p: [string, string, string] = [`${attr.name}`, `${UF(attr.type)};`, `// ${attr.type.namespaced_class_name}`];
+                let p: [string, string, string] = [`${attr.is_static?"static ":""}${attr.is_static_const?"readonly ":""}${attr.name}`, `${UF(attr.type)};`, `// ${attr.type.namespaced_class_name}`];
                 maxLeft = Math.max(maxLeft, p[0].length);
                 maxMiddle = Math.max(maxMiddle, p[1].length);
                 lines.push(p);

--- a/tools/tojs/genbindings.py
+++ b/tools/tojs/genbindings.py
@@ -181,6 +181,7 @@ def main():
             if filename is None: filename = 'jsb_%s_auto' % section
             print ('!!----------Generating bindings for %s----------!!' % (section))
             command = '%s -W ignore %s %s -s %s -t %s -o %s -n %s' % (python_bin, generator_py, cfg, section, target, directory, filename)
+            print ("command : %s" % (command))
             # tasks.append(_run_cmd(command))
             _run_cmd(command).communicate()
 


### PR DESCRIPTION
- 支持通过 `field = ` 字段 static field 导出
- 生成文件忽略 clang-format, 避免格式差异
- 规范生成顺序, 减少平台差异
- 支持重命名 public fields
- 避免重复导出 属性和 对应的getter/setter方法