### PR TITLE
Don't bind ImageAsset::width/height since there are some logic in TS as following, cpp doesn't know the existence which only lives in TS.

### DIFF
--- a/tools/tojs/assets.ini
+++ b/tools/tojs/assets.ini
@@ -90,7 +90,7 @@ rename_functions = ICreateInfo::[structInfo=struct],
                    SceneAsset::[_scene=scene]
 
 getter_setter= Asset::[_uuid/getUuid/setUuid nativeUrl/getNativeUrl _nativeDep/getNativeDep isDefault/isDefault],
-               ImageAsset::[width height format url],
+               ImageAsset::[format url],
                BufferAsset::[buffer],
                TextureBase::[isCompressed/isCompressed width height],
                TextureCube::[mipmaps image],


### PR DESCRIPTION
```ts
    get width () {
        return this._nativeData.width || this._width;
    }

    get height () {
        return this._nativeData.height || this._height;
    }
```