### PR TITLE
HDR is enabled by default in 3.4.0

### DIFF
--- a/cocos/renderer/gfx-agent/SwapchainAgent.cpp
+++ b/cocos/renderer/gfx-agent/SwapchainAgent.cpp
@@ -81,8 +81,8 @@ void SwapchainAgent::doInit(const SwapchainInfo &info) {
 }
 
 void SwapchainAgent::doDestroy() {
-    _depthStencilTexture.release();
-    _colorTexture.release();
+    _depthStencilTexture = nullptr;
+    _colorTexture = nullptr;
 
     ENQUEUE_MESSAGE_1(
         DeviceAgent::getInstance()->getMessageQueue(), SwapchainDestroy,

--- a/cocos/renderer/gfx-agent/SwapchainAgent.cpp
+++ b/cocos/renderer/gfx-agent/SwapchainAgent.cpp
@@ -82,7 +82,7 @@ void SwapchainAgent::doInit(const SwapchainInfo &info) {
 
 void SwapchainAgent::doDestroy() {
     _depthStencilTexture = nullptr;
-    _colorTexture = nullptr;
+    _colorTexture        = nullptr;
 
     ENQUEUE_MESSAGE_1(
         DeviceAgent::getInstance()->getMessageQueue(), SwapchainDestroy,

--- a/cocos/renderer/gfx-validator/SwapchainValidator.cpp
+++ b/cocos/renderer/gfx-validator/SwapchainValidator.cpp
@@ -81,9 +81,8 @@ void SwapchainValidator::doDestroy() {
     _inited = false;
 
     /////////// execute ///////////
-
-    _depthStencilTexture.release();
-    _colorTexture.release();
+    _depthStencilTexture = nullptr;
+    _colorTexture = nullptr;
 
     _actor->destroy();
 }

--- a/cocos/renderer/gfx-validator/SwapchainValidator.cpp
+++ b/cocos/renderer/gfx-validator/SwapchainValidator.cpp
@@ -82,7 +82,7 @@ void SwapchainValidator::doDestroy() {
 
     /////////// execute ///////////
     _depthStencilTexture = nullptr;
-    _colorTexture = nullptr;
+    _colorTexture        = nullptr;
 
     _actor->destroy();
 }

--- a/cocos/renderer/pipeline/PipelineSceneData.h
+++ b/cocos/renderer/pipeline/PipelineSceneData.h
@@ -115,7 +115,7 @@ protected:
     scene::Skybox  *_skybox{nullptr};
     scene::Shadows *_shadow{nullptr};
     scene::Octree  *_octree{nullptr};
-    bool            _isHDR{false};
+    bool            _isHDR{true};
     float           _shadingScale{1.0F};
 
     std::unordered_map<const scene::Light *, gfx::Framebuffer *> _shadowFrameBufferMap;

--- a/cocos/scene/Skybox.h
+++ b/cocos/scene/Skybox.h
@@ -151,7 +151,7 @@ public:
     // @serializable
     bool _useIBL{false};
     // @serializable
-    bool _useHDR{false};
+    bool _useHDR{true};
 
     Skybox *_resource{nullptr};
 };


### PR DESCRIPTION
And assign _depthStencilTexture & _colorTexture to nullptr instead of invoking `SharedPtr::release` method.