### PR TITLE
Use std::shared_ptr to share 'passes' between Material & SubModel.

### DIFF
--- a/cocos/3d/framework/MeshRenderer.cpp
+++ b/cocos/3d/framework/MeshRenderer.cpp
@@ -344,7 +344,7 @@ bool MeshRenderer::isBatchingEnabled() {
             continue;
         }
 
-        for (const auto &pass : mat->getPasses()) {
+        for (const auto &pass : *mat->getPasses()) {
             if (pass->getBatchingScheme() != scene::BatchingSchemes::NONE) {
                 return true;
             }

--- a/cocos/bindings/manual/jsb_conversions.h
+++ b/cocos/bindings/manual/jsb_conversions.h
@@ -1075,7 +1075,7 @@ template <typename Tuple, typename F>
 void se_for_each_tuple(Tuple &&tuple, F &&f) {
     constexpr std::size_t N = std::tuple_size<std::remove_reference_t<Tuple>>::value;
     se_for_each_tuple_impl(std::forward<Tuple>(tuple), std::forward<F>(f),
-                  std::make_index_sequence<N>{});
+                           std::make_index_sequence<N>{});
 }
 
 template <typename... Args>

--- a/cocos/bindings/manual/jsb_conversions.h
+++ b/cocos/bindings/manual/jsb_conversions.h
@@ -698,6 +698,8 @@ template <typename... Args>
 bool sevalue_to_native(const se::Value &from, std::tuple<Args...> *to, se::Object *ctx); // NOLINT(readability-identifier-naming)
 // std::shared_ptr
 template <typename T>
+bool sevalue_to_native(const se::Value &from, std::shared_ptr<std::vector<T>> *out, se::Object *ctx); // NOLINT(readability-identifier-naming)
+template <typename T>
 bool sevalue_to_native(const se::Value &from, std::shared_ptr<T> *out, se::Object *ctx); // NOLINT(readability-identifier-naming)
 // std::vector
 template <typename T, typename Allocator>
@@ -1009,6 +1011,17 @@ sevalue_to_native(const se::Value &from, HolderType<std::vector<T, allocator>, t
 #endif // HAS_CONSTEXPR
 
 /////////////////// std::shared_ptr
+
+template <typename T>
+bool sevalue_to_native(const se::Value &from, std::shared_ptr<std::vector<T>> *out, se::Object *ctx) {
+    if (from.isNullOrUndefined()) {
+        out->reset();
+        return true;
+    }
+
+    *out = std::make_shared<std::vector<T>>();
+    return sevalue_to_native(from, out->get(), ctx);
+}
 
 template <typename T>
 bool sevalue_to_native(const se::Value &from, std::shared_ptr<T> *out, se::Object *ctx) {
@@ -1421,6 +1434,12 @@ bool nativevalue_to_se(const cc::variant<ARGS...> &from, se::Value &to, se::Obje
         from);
     return ok;
 }
+
+template <typename T>
+inline bool nativevalue_to_se(const std::shared_ptr<std::vector<T>> &from, se::Value &to, se::Object *ctx) { //NOLINT
+    return nativevalue_to_se(*from, to, ctx);
+}
+
 template <typename T>
 inline bool nativevalue_to_se(const std::shared_ptr<T> &from, se::Value &to, se::Object *ctx) { //NOLINT
 

--- a/cocos/core/assets/Material.cpp
+++ b/cocos/core/assets/Material.cpp
@@ -44,17 +44,23 @@ uint64_t Material::getHashForMaterial(Material *material) {
     }
 
     uint64_t hash = 0;
-    for (const auto &pass : material->_passes) {
+    const auto& passes = *material->_passes;
+    for (const auto &pass : passes) {
         hash ^= pass->getHash();
     }
     return hash;
+}
+
+Material::Material() {
+    _passes = std::make_shared<std::vector<SharedPtr<scene::Pass>>>();
 }
 
 void Material::initialize(const IMaterialInfo &info) {
     // cjh FIXME: remove hacking code here
     BuiltinResMgr::getInstance();
     //
-    if (!_passes.empty()) {
+    auto& passes = *_passes;
+    if (!passes.empty()) {
         // cjh TODO:        warnID(12005);
         return;
     }
@@ -99,12 +105,14 @@ bool Material::destroy() {
 }
 
 void Material::doDestroy() {
-    if (!_passes.empty()) {
-        for (const auto &pass : _passes) {
+    auto& passes = *_passes;
+    if (!passes.empty()) {
+        for (const auto &pass : passes) {
             pass->destroy();
         }
     }
-    _passes.clear();
+    passes.clear();
+    emit(EventTypesToJS::MATERIAL_PASSES_UPDATED);
 }
 
 void Material::recompileShaders(const MacroRecord & /*overrides*/, index_t /*passIdx*/) {
@@ -122,36 +130,38 @@ void Material::onLoaded() {
 }
 
 void Material::resetUniforms(bool clearPasses /* = true */) {
-    _props.resize(_passes.size());
+    const auto& passes = *_passes;
+    _props.resize(passes.size());
 
     if (!clearPasses) {
         return;
     }
 
-    for (const auto &pass : _passes) {
+    for (const auto &pass : passes) {
         pass->resetUBOs();
         pass->resetTextures();
     }
 }
 
 void Material::setProperty(const std::string &name, const MaterialPropertyVariant &val, index_t passIdx /* = CC_INVALID_INDEX */) {
+    const auto& passes = *_passes;
     bool success = false;
     if (passIdx == CC_INVALID_INDEX) { // try set property for all applicable passes
-        size_t len = _passes.size();
+        size_t len = passes.size();
         for (size_t i = 0; i < len; i++) {
-            const auto &pass = _passes[i];
+            const auto &pass = passes[i];
             if (uploadProperty(pass, name, val)) {
                 _props[pass->getPropertyIndex()][name] = val;
                 success                                = true;
             }
         }
     } else {
-        if (passIdx >= _passes.size()) {
+        if (passIdx >= passes.size()) {
             CC_LOG_WARNING("illegal pass index: %d.", passIdx);
             return;
         }
 
-        const auto &pass = _passes[passIdx];
+        const auto &pass = passes[passIdx];
         if (uploadProperty(pass, name, val)) {
             _props[pass->getPropertyIndex()][name] = val;
             success                                = true;
@@ -223,7 +233,8 @@ const MaterialPropertyVariant *Material::getProperty(const std::string &name, in
             return nullptr;
         }
 
-        const auto &props = _props[_passes[passIdx]->getPropertyIndex()];
+        const auto& passes = *_passes;
+        const auto &props = _props[passes[passIdx]->getPropertyIndex()];
         auto        iter  = props.find(name);
         if (iter != props.end()) {
             return &iter->second;
@@ -256,7 +267,7 @@ void Material::copy(const Material *mat) {
 
 void Material::update(bool keepProps /* = true*/) {
     if (_effectAsset) {
-        _passes = createPasses();
+        *_passes = createPasses();
         CC_ASSERT(!_effectAsset->_techniques.empty());
         // handle property values
         size_t totalPasses = _effectAsset->_techniques[_techIdx].passes.size();
@@ -278,8 +289,9 @@ void Material::update(bool keepProps /* = true*/) {
                 }
             };
 
-            for (size_t i = 0, len = _passes.size(); i < len; ++i) {
-                cb(_passes[i].get(), i);
+            const auto& passes = *_passes;
+            for (size_t i = 0, len = passes.size(); i < len; ++i) {
+                cb(passes[i].get(), i);
             }
         }
         // cjh FIXME: no need since we resize _props?
@@ -428,7 +440,7 @@ void Material::initDefault(const cc::optional<std::string> &uuid) {
 }
 
 bool Material::validate() const {
-    return _effectAsset != nullptr && !_effectAsset->isDefault() && !_passes.empty();
+    return _effectAsset != nullptr && !_effectAsset->isDefault() && !_passes->empty();
 }
 
 } // namespace cc

--- a/cocos/core/assets/Material.cpp
+++ b/cocos/core/assets/Material.cpp
@@ -43,8 +43,8 @@ uint64_t Material::getHashForMaterial(Material *material) {
         return 0;
     }
 
-    uint64_t hash = 0;
-    const auto& passes = *material->_passes;
+    uint64_t    hash   = 0;
+    const auto &passes = *material->_passes;
     for (const auto &pass : passes) {
         hash ^= pass->getHash();
     }
@@ -59,7 +59,7 @@ void Material::initialize(const IMaterialInfo &info) {
     // cjh FIXME: remove hacking code here
     BuiltinResMgr::getInstance();
     //
-    auto& passes = *_passes;
+    auto &passes = *_passes;
     if (!passes.empty()) {
         // cjh TODO:        warnID(12005);
         return;
@@ -105,7 +105,7 @@ bool Material::destroy() {
 }
 
 void Material::doDestroy() {
-    auto& passes = *_passes;
+    auto &passes = *_passes;
     if (!passes.empty()) {
         for (const auto &pass : passes) {
             pass->destroy();
@@ -130,7 +130,7 @@ void Material::onLoaded() {
 }
 
 void Material::resetUniforms(bool clearPasses /* = true */) {
-    const auto& passes = *_passes;
+    const auto &passes = *_passes;
     _props.resize(passes.size());
 
     if (!clearPasses) {
@@ -144,8 +144,8 @@ void Material::resetUniforms(bool clearPasses /* = true */) {
 }
 
 void Material::setProperty(const std::string &name, const MaterialPropertyVariant &val, index_t passIdx /* = CC_INVALID_INDEX */) {
-    const auto& passes = *_passes;
-    bool success = false;
+    const auto &passes  = *_passes;
+    bool        success = false;
     if (passIdx == CC_INVALID_INDEX) { // try set property for all applicable passes
         size_t len = passes.size();
         for (size_t i = 0; i < len; i++) {
@@ -233,9 +233,9 @@ const MaterialPropertyVariant *Material::getProperty(const std::string &name, in
             return nullptr;
         }
 
-        const auto& passes = *_passes;
-        const auto &props = _props[passes[passIdx]->getPropertyIndex()];
-        auto        iter  = props.find(name);
+        const auto &passes = *_passes;
+        const auto &props  = _props[passes[passIdx]->getPropertyIndex()];
+        auto        iter   = props.find(name);
         if (iter != props.end()) {
             return &iter->second;
         }
@@ -289,7 +289,7 @@ void Material::update(bool keepProps /* = true*/) {
                 }
             };
 
-            const auto& passes = *_passes;
+            const auto &passes = *_passes;
             for (size_t i = 0, len = passes.size(); i < len; ++i) {
                 cb(passes[i].get(), i);
             }
@@ -434,7 +434,7 @@ void Material::initDefault(const cc::optional<std::string> &uuid) {
     MacroRecord   defines{{"USE_COLOR", true}};
     IMaterialInfo info;
     info.effectName = std::string{"unlit"};
-    info.defines    = IMaterialInfo::DefinesType { defines };
+    info.defines    = IMaterialInfo::DefinesType{defines};
     initialize(info);
     setProperty("mainColor", Color{0xFF, 0x00, 0xFF, 0xFF});
 }

--- a/cocos/core/assets/Material.h
+++ b/cocos/core/assets/Material.h
@@ -103,7 +103,7 @@ public:
         return static_cast<double>(getHashForMaterial(material));
     }
 
-    Material()           = default;
+    Material();
     ~Material() override = default;
 
     /**
@@ -239,7 +239,7 @@ public:
     //
 
 protected:
-    std::vector<SharedPtr<scene::Pass>> _passes;
+    std::shared_ptr<std::vector<SharedPtr<scene::Pass>>> _passes;
 
     uint64_t _hash{0};
 
@@ -280,7 +280,7 @@ public:
      * @en The passes defined in this material.
      * @zh 当前正在使用的 pass 数组。
      */
-    std::vector<SharedPtr<scene::Pass>> &getPasses() {
+    std::shared_ptr<std::vector<SharedPtr<scene::Pass>>> &getPasses() {
         return _passes;
     }
 

--- a/cocos/core/builtin/BuiltinResMgr.cpp
+++ b/cocos/core/builtin/BuiltinResMgr.cpp
@@ -452,7 +452,8 @@ void BuiltinResMgr::initMaterials() {
 
 void BuiltinResMgr::tryCompileAllPasses() {
     for (auto &mat : _materialsToBeCompiled) {
-        for (auto &pass : mat->getPasses()) {
+        auto& passes = *mat->getPasses();
+        for (auto &pass : passes) {
             pass->tryCompile();
         }
     }

--- a/cocos/core/builtin/BuiltinResMgr.cpp
+++ b/cocos/core/builtin/BuiltinResMgr.cpp
@@ -452,7 +452,7 @@ void BuiltinResMgr::initMaterials() {
 
 void BuiltinResMgr::tryCompileAllPasses() {
     for (auto &mat : _materialsToBeCompiled) {
-        auto& passes = *mat->getPasses();
+        auto &passes = *mat->getPasses();
         for (auto &pass : passes) {
             pass->tryCompile();
         }

--- a/cocos/renderer/core/MaterialInstance.cpp
+++ b/cocos/renderer/core/MaterialInstance.cpp
@@ -12,7 +12,7 @@ MaterialInstance::MaterialInstance(const IMaterialInstanceInfo &info) {
 }
 
 void MaterialInstance::recompileShaders(const MacroRecord &overrides, index_t passIdx /* = CC_INVALID_INDEX */) {
-    auto& passes = *_passes;
+    auto &passes = *_passes;
     if (passes.empty() || _effectAsset == nullptr) {
         return;
     }
@@ -30,7 +30,7 @@ void MaterialInstance::recompileShaders(const MacroRecord &overrides, index_t pa
 }
 
 void MaterialInstance::overridePipelineStates(const PassOverrides &overrides, index_t passIdx /* = CC_INVALID_INDEX */) {
-    auto& passes = *_passes;
+    auto &passes = *_passes;
     if (passes.empty() || _effectAsset == nullptr) {
         return;
     }

--- a/cocos/renderer/core/MaterialInstance.cpp
+++ b/cocos/renderer/core/MaterialInstance.cpp
@@ -12,31 +12,33 @@ MaterialInstance::MaterialInstance(const IMaterialInstanceInfo &info) {
 }
 
 void MaterialInstance::recompileShaders(const MacroRecord &overrides, index_t passIdx /* = CC_INVALID_INDEX */) {
-    if (_passes.empty() || _effectAsset == nullptr) {
+    auto& passes = *_passes;
+    if (passes.empty() || _effectAsset == nullptr) {
         return;
     }
 
     if (passIdx == CC_INVALID_INDEX) {
-        for (const auto &pass : _passes) {
+        for (const auto &pass : passes) {
             pass->tryCompile(overrides);
         }
     } else {
-        if (passIdx < _passes.size()) {
-            auto *pass = _passes[passIdx].get();
+        if (passIdx < passes.size()) {
+            auto *pass = passes[passIdx].get();
             pass->tryCompile(overrides);
         }
     }
 }
 
 void MaterialInstance::overridePipelineStates(const PassOverrides &overrides, index_t passIdx /* = CC_INVALID_INDEX */) {
-    if (_passes.empty() || _effectAsset == nullptr) {
+    auto& passes = *_passes;
+    if (passes.empty() || _effectAsset == nullptr) {
         return;
     }
 
     std::vector<IPassInfoFull> &passInfos = _effectAsset->_techniques[getTechniqueIndex()].passes;
     if (passIdx == CC_INVALID_INDEX) {
-        for (size_t i = 0, len = _passes.size(); i < len; i++) {
-            auto *pass = _passes[i].get();
+        for (size_t i = 0, len = passes.size(); i < len; i++) {
+            auto *pass = passes[i].get();
             if (i >= _states.size()) {
                 _states.resize(i + 1);
             }
@@ -50,7 +52,7 @@ void MaterialInstance::overridePipelineStates(const PassOverrides &overrides, in
         }
         auto &state = _states[passIdx];
         state.overrides(IPassInfoFull(overrides));
-        _passes[passIdx]->overridePipelineStates(passInfos[passIdx], state);
+        passes[passIdx]->overridePipelineStates(passInfos[passIdx], state);
     }
 }
 
@@ -59,21 +61,12 @@ bool MaterialInstance::destroy() {
     return true;
 }
 
-void MaterialInstance::doDestroy() {
-    if (!_passes.empty()) {
-        for (const auto &pass : _passes) {
-            pass->destroy();
-        }
-    }
-    _passes.clear();
-}
-
 std::vector<SharedPtr<scene::Pass>> MaterialInstance::createPasses() {
     std::vector<SharedPtr<scene::Pass>> passes;
     auto &                              parentPasses = _parent->getPasses();
 
-    passes.reserve(parentPasses.size());
-    for (auto &parentPass : parentPasses) {
+    passes.reserve(parentPasses->size());
+    for (auto &parentPass : *parentPasses) {
         passes.emplace_back(new PassInstance(parentPass, this));
     }
     return passes;

--- a/cocos/renderer/core/MaterialInstance.h
+++ b/cocos/renderer/core/MaterialInstance.h
@@ -70,8 +70,6 @@ public:
 
     bool destroy() override;
 
-    void doDestroy() override;
-
     void onPassStateChange(bool dontNotify);
 
     // For JS

--- a/cocos/renderer/pipeline/PipelineSceneData.cpp
+++ b/cocos/renderer/pipeline/PipelineSceneData.cpp
@@ -84,14 +84,14 @@ void PipelineSceneData::initOcclusionQuery() {
         IMaterialInfo info;
         info.effectName = "occlusion-query";
         _occlusionQueryMaterial->initialize(info);
-        _occlusionQueryPass   = _occlusionQueryMaterial->getPasses()[0];
+        _occlusionQueryPass   = (*_occlusionQueryMaterial->getPasses())[0];
         _occlusionQueryShader = _occlusionQueryPass->getShaderVariant();
     }
 }
 
 scene::Pass *PipelineSceneData::getOcclusionQueryPass() {
     if (_occlusionQueryMaterial) {
-        const auto &passes = _occlusionQueryMaterial->getPasses();
+        const auto &passes = *_occlusionQueryMaterial->getPasses();
         return passes[0].get();
     }
 

--- a/cocos/renderer/pipeline/PlanarShadowQueue.cpp
+++ b/cocos/renderer/pipeline/PlanarShadowQueue.cpp
@@ -73,7 +73,7 @@ void PlanarShadowQueue::gatherShadowPasses(scene::Camera *camera, gfx::CommandBu
         }
     }
 
-    auto& passes = *shadows->getInstancingMaterial()->getPasses();
+    auto &           passes          = *shadows->getInstancingMaterial()->getPasses();
     InstancedBuffer *instancedBuffer = passes[0]->getInstancedBuffer();
 
     geometry::AABB ab;

--- a/cocos/renderer/pipeline/PlanarShadowQueue.cpp
+++ b/cocos/renderer/pipeline/PlanarShadowQueue.cpp
@@ -73,7 +73,8 @@ void PlanarShadowQueue::gatherShadowPasses(scene::Camera *camera, gfx::CommandBu
         }
     }
 
-    InstancedBuffer *instancedBuffer = shadows->getInstancingMaterial()->getPasses()[0]->getInstancedBuffer();
+    auto& passes = *shadows->getInstancingMaterial()->getPasses();
+    InstancedBuffer *instancedBuffer = passes[0]->getInstancedBuffer();
 
     geometry::AABB ab;
     for (const auto *model : _castModels) {
@@ -117,7 +118,7 @@ void PlanarShadowQueue::recordCommandBuffer(gfx::Device *device, gfx::RenderPass
         return;
     }
 
-    const scene::Pass *pass = shadows->getMaterial()->getPasses()[0];
+    const scene::Pass *pass = (*shadows->getMaterial()->getPasses())[0];
     cmdBuffer->bindDescriptorSet(materialSet, pass->getDescriptorSet());
 
     for (const auto *model : _pendingModels) {

--- a/cocos/renderer/pipeline/deferred/DeferredPipelineSceneData.cpp
+++ b/cocos/renderer/pipeline/deferred/DeferredPipelineSceneData.cpp
@@ -72,7 +72,7 @@ void DeferredPipelineSceneData::updateBloomPass() {
         return;
     }
 
-    auto& bloomPasses = *_bloomMaterial->getPasses();
+    auto &bloomPasses   = *_bloomMaterial->getPasses();
     _bloomPrefilterPass = bloomPasses[BLOOM_PREFILTERPASS_INDEX];
     _bloomPrefilterPass->beginChangeStatesSilently();
     _bloomPrefilterPass->tryCompile();

--- a/cocos/scene/Shadow.cpp
+++ b/cocos/scene/Shadow.cpp
@@ -221,7 +221,8 @@ gfx::Shader *Shadows::getPlanarShader(const std::vector<IMacroPatch> &patches) {
         createMaterial();
     }
 
-    return _material->getPasses()[0]->getShaderVariant(patches);
+    const auto& passes = *_material->getPasses();
+    return passes[0]->getShaderVariant(patches);
 }
 
 gfx::Shader *Shadows::getPlanarInstanceShader(const std::vector<IMacroPatch> &patches) {
@@ -229,7 +230,8 @@ gfx::Shader *Shadows::getPlanarInstanceShader(const std::vector<IMacroPatch> &pa
         createInstanceMaterial();
     }
 
-    return _instancingMaterial->getPasses()[0]->getShaderVariant(patches);
+    const auto& passes = *_instancingMaterial->getPasses();
+    return passes[0]->getShaderVariant(patches);
 }
 
 void Shadows::activate() {

--- a/cocos/scene/Shadow.cpp
+++ b/cocos/scene/Shadow.cpp
@@ -25,9 +25,9 @@
 
 #include "scene/Shadow.h"
 #include <cmath>
+#include "core/Root.h"
 #include "core/scene-graph/Node.h"
 #include "scene/Pass.h"
-#include "core/Root.h"
 
 namespace cc {
 namespace scene {
@@ -185,8 +185,8 @@ void ShadowsInfo::activate(Shadows *resource) {
 const float Shadows::COEFFICIENT_OF_EXPANSION{2.0F * std::sqrt(3.0F)};
 
 void Shadows::initialize(const ShadowsInfo &shadowsInfo) {
-    _near      = shadowsInfo.getNear();
-    _far       = shadowsInfo.getFar();
+    _near = shadowsInfo.getNear();
+    _far  = shadowsInfo.getFar();
     setInvisibleOcclusionRange(shadowsInfo.getInvisibleOcclusionRange());
     setShadowDistance(shadowsInfo.getShadowDistance());
     _orthoSize = shadowsInfo.getOrthoSize();
@@ -221,7 +221,7 @@ gfx::Shader *Shadows::getPlanarShader(const std::vector<IMacroPatch> &patches) {
         createMaterial();
     }
 
-    const auto& passes = *_material->getPasses();
+    const auto &passes = *_material->getPasses();
     return passes[0]->getShaderVariant(patches);
 }
 
@@ -230,7 +230,7 @@ gfx::Shader *Shadows::getPlanarInstanceShader(const std::vector<IMacroPatch> &pa
         createInstanceMaterial();
     }
 
-    const auto& passes = *_instancingMaterial->getPasses();
+    const auto &passes = *_instancingMaterial->getPasses();
     return passes[0]->getShaderVariant(patches);
 }
 

--- a/cocos/scene/SubModel.cpp
+++ b/cocos/scene/SubModel.cpp
@@ -41,7 +41,7 @@ const static uint32_t  MAX_PASS_COUNT = 8;
 gfx::DescriptorSetInfo dsInfo         = gfx::DescriptorSetInfo();
 
 void SubModel::update() {
-    auto& passes = *_passes;
+    auto &passes = *_passes;
     for (Pass *pass : passes) {
         pass->update();
     }
@@ -58,7 +58,7 @@ void SubModel::setPasses(const std::shared_ptr<std::vector<SharedPtr<Pass>>> &pP
     _passes = pPasses;
     flushPassInfo();
 
-    const auto& passes = *_passes;
+    const auto &passes = *_passes;
     if (passes[0].get()->getBatchingScheme() == BatchingSchemes::VB_MERGING) {
         _subMesh->genFlatBuffers();
     }
@@ -79,7 +79,7 @@ gfx::Shader *SubModel::getShader(uint index) const {
 }
 
 Pass *SubModel::getPass(uint index) const {
-    auto& passes = *_passes;
+    auto &passes = *_passes;
     if (index >= passes.size()) {
         return nullptr;
     }
@@ -105,7 +105,7 @@ void SubModel::initialize(RenderingSubMesh *subMesh, const std::shared_ptr<std::
 
     flushPassInfo();
 
-    const auto& passes = *_passes;
+    const auto &passes = *_passes;
     if (passes[0]->getBatchingScheme() == BatchingSchemes::VB_MERGING) {
         subMesh->genFlatBuffers();
     }
@@ -190,7 +190,7 @@ void SubModel::destroy() {
 }
 
 void SubModel::onPipelineStateChanged() {
-    auto& passes = *_passes;
+    auto &passes = *_passes;
     if (passes.empty()) return;
 
     for (Pass *pass : passes) {
@@ -202,8 +202,8 @@ void SubModel::onPipelineStateChanged() {
 }
 
 void SubModel::onMacroPatchesStateChanged(const std::vector<IMacroPatch> &patches) {
-    _patches = patches;
-    auto& passes = *_passes;
+    _patches     = patches;
+    auto &passes = *_passes;
     if (passes.empty()) return;
     for (Pass *pass : passes) {
         pass->beginChangeStatesSilently();
@@ -214,7 +214,7 @@ void SubModel::onMacroPatchesStateChanged(const std::vector<IMacroPatch> &patche
 }
 
 void SubModel::flushPassInfo() {
-    auto& passes = *_passes;
+    auto &passes = *_passes;
     if (passes.empty()) return;
     if (!_shaders.empty()) {
         _shaders.clear();
@@ -226,7 +226,7 @@ void SubModel::flushPassInfo() {
 }
 
 void SubModel::setSubMesh(RenderingSubMesh *subMesh) {
-    auto& passes = *_passes;
+    auto &passes = *_passes;
     _inputAssembler->destroy();
     _inputAssembler->initialize(subMesh->getIaInfo());
     if (passes[0]->getBatchingScheme() == BatchingSchemes::VB_MERGING) {

--- a/cocos/scene/SubModel.h
+++ b/cocos/scene/SubModel.h
@@ -52,7 +52,7 @@ public:
     inline void setDescriptorSet(gfx::DescriptorSet *descriptorSet) { _descriptorSet = descriptorSet; }
     inline void setInputAssembler(gfx::InputAssembler *ia) { _inputAssembler = ia; }
     inline void setShaders(const std::vector<SharedPtr<gfx::Shader>> &shaders) { _shaders = shaders; }
-    void        setPasses(const std::vector<SharedPtr<Pass>> &passes);
+    void        setPasses(const std::shared_ptr<std::vector<SharedPtr<Pass>>> &passes);
     inline void setPlanarInstanceShader(gfx::Shader *shader) { _planarInstanceShader = shader; }
     inline void setPlanarShader(gfx::Shader *shader) { _planarShader = shader; }
     inline void setPriority(pipeline::RenderPriority priority) { _priority = priority; }
@@ -63,7 +63,7 @@ public:
     inline gfx::DescriptorSet *                       getWorldBoundDescriptorSet() const { return _worldBoundDescriptorSet; }
     inline gfx::InputAssembler *                      getInputAssembler() const { return _inputAssembler; }
     inline const std::vector<SharedPtr<gfx::Shader>> &getShaders() const { return _shaders; }
-    inline const std::vector<SharedPtr<Pass>> &       getPasses() const { return _passes; }
+    inline const std::vector<SharedPtr<Pass>> &       getPasses() const { return *_passes; }
     inline const std::vector<IMacroPatch> &           getPatches() const { return _patches; }
     inline gfx::Shader *                              getPlanarInstanceShader() const { return _planarInstanceShader; }
     inline gfx::Shader *                              getPlanarShader() const { return _planarShader; }
@@ -72,7 +72,7 @@ public:
     inline Model *                                    getOwner() const { return _owner; }
     inline uint32_t                                   getId() const { return _id; }
 
-    void initialize(RenderingSubMesh *subMesh, const std::vector<SharedPtr<Pass>> &passes, const std::vector<IMacroPatch> &patches);
+    void initialize(RenderingSubMesh *subMesh, const std::shared_ptr<std::vector<SharedPtr<Pass>>> &passes, const std::vector<IMacroPatch> &patches);
     void initPlanarShadowShader();
     void initPlanarShadowInstanceShader();
     void destroy();
@@ -94,11 +94,10 @@ protected:
     SharedPtr<gfx::Shader>              _planarShader;
     SharedPtr<gfx::Shader>              _planarInstanceShader;
     SharedPtr<RenderingSubMesh>         _subMesh;
-    std::vector<SharedPtr<Pass>>        _passes;
+    std::shared_ptr<std::vector<SharedPtr<Pass>>>        _passes;
     std::vector<SharedPtr<gfx::Shader>> _shaders;
     Model *                             _owner{nullptr};
     int32_t                            _id{-1};
-
 private:
     static inline uint32_t generateId() {
         static uint32_t generator = 0;

--- a/cocos/scene/SubModel.h
+++ b/cocos/scene/SubModel.h
@@ -88,16 +88,17 @@ protected:
     SharedPtr<gfx::DescriptorSet>  _descriptorSet;
     SharedPtr<gfx::DescriptorSet>  _worldBoundDescriptorSet;
 
-    SharedPtr<gfx::Texture>             _reflectionTex;
-    SharedPtr<gfx::Sampler>             _reflectionSampler;
-    pipeline::RenderPriority            _priority{pipeline::RenderPriority::DEFAULT};
-    SharedPtr<gfx::Shader>              _planarShader;
-    SharedPtr<gfx::Shader>              _planarInstanceShader;
-    SharedPtr<RenderingSubMesh>         _subMesh;
-    std::shared_ptr<std::vector<SharedPtr<Pass>>>        _passes;
-    std::vector<SharedPtr<gfx::Shader>> _shaders;
-    Model *                             _owner{nullptr};
-    int32_t                            _id{-1};
+    SharedPtr<gfx::Texture>                       _reflectionTex;
+    SharedPtr<gfx::Sampler>                       _reflectionSampler;
+    pipeline::RenderPriority                      _priority{pipeline::RenderPriority::DEFAULT};
+    SharedPtr<gfx::Shader>                        _planarShader;
+    SharedPtr<gfx::Shader>                        _planarInstanceShader;
+    SharedPtr<RenderingSubMesh>                   _subMesh;
+    std::shared_ptr<std::vector<SharedPtr<Pass>>> _passes;
+    std::vector<SharedPtr<gfx::Shader>>           _shaders;
+    Model *                                       _owner{nullptr};
+    int32_t                                       _id{-1};
+
 private:
     static inline uint32_t generateId() {
         static uint32_t generator = 0;

--- a/cocos/terrain/Terrain.cpp
+++ b/cocos/terrain/Terrain.cpp
@@ -114,10 +114,10 @@ void TerrainRenderable::invalidMaterial() {
         return;
     }
 
-    if (_brushMaterial != nullptr && !_brushMaterial->getPasses().empty()) {
-        auto &passes = _currentMaterial->getPasses();
+    if (_brushMaterial != nullptr && !_brushMaterial->getPasses()->empty()) {
+        auto &passes = *_currentMaterial->getPasses();
         for (size_t i = 0; i < passes.size(); ++i) {
-            if (passes[i] == _brushMaterial->getPasses()[0]) {
+            if (passes[i] == (*_brushMaterial->getPasses())[0]) {
                 passes.pop_back();
                 break;
             }
@@ -146,9 +146,9 @@ void TerrainRenderable::updateMaterial(TerrainBlock *block, bool init) {
         info.defines     = block->getMaterialDefines(nLayers);
         _currentMaterial->initialize(info);
 
-        if (_brushMaterial != nullptr && !_brushMaterial->getPasses().empty()) {
-            auto &passes = _currentMaterial->getPasses();
-            passes.emplace_back(_brushMaterial->getPasses()[0]);
+        if (_brushMaterial != nullptr && !_brushMaterial->getPasses()->empty()) {
+            auto &passes = *_currentMaterial->getPasses();
+            passes.emplace_back((*_brushMaterial->getPasses())[0]);
         }
 
         if (init) {


### PR DESCRIPTION
Fix crash of mask-use-image-stencil test case.